### PR TITLE
Added support for forceflash for local devices.

### DIFF
--- a/icetea_lib/Plugin/plugins/LocalAllocator.py
+++ b/icetea_lib/Plugin/plugins/LocalAllocator.py
@@ -75,7 +75,7 @@ def init_hardware_dut(contextlist, conf, index, args):
         if contextlist.check_flashing_need('hardware',
                                            binary,
                                            args.forceflash):
-            if dut.flash(binary=binary):
+            if dut.flash(binary=binary, forceflash=args.forceflash):
                 contextlist.logger.info('flash ready')
             else:
                 dut.close_dut(False)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
           "pyserial>2.5",
           "jsonmerge",
           "psutil",
-          "mbed-ls>=1.4.2,==1.*",
+          "mbed-ls>=1.5.1,==1.*",
           "semver",
           "mbed-flasher==0.9.*",
           "six"

--- a/test/test_dutinformation.py
+++ b/test/test_dutinformation.py
@@ -50,6 +50,33 @@ class DutInfoTestcase(unittest.TestCase):
     def test_get_resourceids(self):
         self.assertListEqual(self.testlist.get_resource_ids(), ['12345', '23456', '34567'])
 
+    def test_cache(self):
+        # pylint: disable=W0212
+        DutInformationList._cache = dict()
+        self.assertDictEqual(DutInformationList._cache, dict())
+
+        DutInformationList.push_resource_cache("test", {"a": "1"})
+        self.assertDictEqual(DutInformationList._cache, {"test": {"a": "1"}})
+
+        DutInformationList.get_resource_cache("test")["b"] = "2"
+        self.assertDictEqual(DutInformationList._cache, {"test": {"a": "1", "b": "2"}})
+
+        DutInformationList.push_resource_cache("test", {"a": "2"})
+        self.assertDictEqual(DutInformationList._cache, {"test": {"a": "2", "b": "2"}})
+
+        DutInformationList._cache = dict()
+        self.assertDictEqual(DutInformationList._cache, dict())
+
+    def test_build_sha(self):
+        # pylint: disable=W0212
+        DutInformationList._cache = dict()
+        info = DutInformation("plat1", "12345", "1", "vendor")
+        self.assertEqual(info.build_binary_sha1, None)
+        info.build_binary_sha1 = "123"
+        self.assertEqual(info.build_binary_sha1, "123")
+        DutInformationList._cache = dict()
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_dutserial.py
+++ b/test/test_dutserial.py
@@ -125,6 +125,33 @@ class DutSerialTestcase(unittest.TestCase):
             with self.assertRaises(DutConnectionError):
                 dut.flash("try4")
 
+    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager.get_bench_logger")
+    @mock.patch("icetea_lib.DeviceConnectors.DutSerial.inspect")
+    @mock.patch("icetea_lib.DeviceConnectors.DutSerial.get_resourceprovider_logger")
+    @mock.patch("icetea_lib.DeviceConnectors.DutSerial.Flash")
+    @mock.patch("icetea_lib.DeviceConnectors.DutSerial.Build")
+    def test_flash_skip_flash(self, mock_build, mock_flasher, mocked_logger, mock_inspect,
+                              mock_bench_logger):
+        mock_build_object = mock.MagicMock()
+        mock_build_object.get_file = mock.MagicMock(return_value="Thisbin")
+        mock_build.init = mock.MagicMock(return_value=mock_build_object)
+        mock_inspect.getargspec = mock.MagicMock()
+        mock_inspect.getargspec.return_value = MockArgspec(["logger"])
+        mock_logger_for_flasher = mock.MagicMock()
+        mocked_logger.return_value = mock_logger_for_flasher
+        mock_flasher_object = mock.MagicMock()
+        mock_flasher.return_value = mock_flasher_object
+        mock_flasher_object.flash = mock.MagicMock()
+        mock_flasher_object.flash.side_effect = [0]
+        dut = DutSerial(port="test", config={
+            "allocated": {"target_id": "thing"},
+            "application": "thing"
+        })
+        self.assertTrue(dut.flash("try"))
+        self.assertTrue(dut.flash("try"))
+        self.assertTrue(dut.flash("try"))
+        self.assertEqual(mock_flasher_object.flash.call_count, 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_dutserial.py
+++ b/test/test_dutserial.py
@@ -142,7 +142,7 @@ class DutSerialTestcase(unittest.TestCase):
         mock_flasher_object = mock.MagicMock()
         mock_flasher.return_value = mock_flasher_object
         mock_flasher_object.flash = mock.MagicMock()
-        mock_flasher_object.flash.side_effect = [0]
+        mock_flasher_object.flash.return_value = 0
         dut = DutSerial(port="test", config={
             "allocated": {"target_id": "thing"},
             "application": "thing"
@@ -151,6 +151,8 @@ class DutSerialTestcase(unittest.TestCase):
         self.assertTrue(dut.flash("try"))
         self.assertTrue(dut.flash("try"))
         self.assertEqual(mock_flasher_object.flash.call_count, 1)
+        self.assertTrue(dut.flash("try", forceflash=True))
+        self.assertEqual(mock_flasher_object.flash.call_count, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Status
**READY**

## Description
Supporting forceflash-option for local devices. Icetea now skips flashing the device if the binary sha1 is the same as on a previous test case for a dut. HOX: Only works when running multiple tests in a row. The first test case will still always flash the binary, if a binary has been given.

## Todos
- [x] Tests