### PR TITLE
Remove psutil from dependencies

### DIFF
--- a/doc-source/Icetea.rst
+++ b/doc-source/Icetea.rst
@@ -39,7 +39,6 @@ installed by `Icetea` installation.
     * requests (`pip install requests`)
     * coverage (`pip install coverage`), for unit tests.
     * mock  (`pip install mock`), for unit tests.
-    * psutil (`pip install psutil`)
     * coloredlogs (`pip install coloredlogs`), optional
     * semver (`pip install semver`)
     * six (`pip install six`)

--- a/doc/Icetea.md
+++ b/doc/Icetea.md
@@ -34,7 +34,6 @@ installed by `Icetea` installation.
  * requests (`pip install requests`)
  * coverage (`pip install coverage`), for unit tests.
  * mock  (`pip install mock`), for unit tests.
- * psutil (`pip install psutil`)
  * coloredlogs (`pip install coloredlogs`), optional
  * semver (`pip install semver`)
  * six (`pip install six`)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ INSTALL_REQUIRES = [
           "yattag",
           "pyserial>2.5",
           "jsonmerge",
-          "psutil",
           "mbed-ls>=1.5.1,==1.*",
           "semver",
           "mbed-flasher==0.9.*",


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Remove psutil from dependencies list because it is used only in case of wshark. @jonikula will document it in better way on Monday

Only impact is that we don't need to install python-dev if wshark feature is not needed, then it is optional