### PR TITLE
Changed console report handling for the case where all test were skipped

### DIFF
--- a/icetea_lib/Reports/ReportConsole.py
+++ b/icetea_lib/Reports/ReportConsole.py
@@ -56,7 +56,9 @@ class ReportConsole(ReportBase):
         # Generate Summary table
         table = PrettyTable(['Summary', ''])
         final_verdict = "FAIL"
-        if self.summary["fail"] == 0 and self.summary["inconclusive"] == 0:
+        if self.summary["skip"] == self.summary["count"]:
+            final_verdict = "INCONCLUSIVE"
+        elif self.summary["fail"] == 0 and self.summary["inconclusive"] == 0:
             final_verdict = "PASS"
         elif self.summary["fail"] == 0 and self.summary["inconclusive"] > 0:
             final_verdict = "INCONCLUSIVE"

--- a/test/test_reports.py
+++ b/test/test_reports.py
@@ -77,6 +77,25 @@ class ReportCase(unittest.TestCase):
         finally:
             sys.stdout = saved_stdout
 
+    def test_reportconsole_not_just_skips(self):
+        saved_stdout = sys.stdout
+        results = ResultList()
+        results.append(Result({"verdict": "skip"}))
+        results.append(Result({"verdict": "pass"}))
+        try:
+            out = StringIO()
+            sys.stdout = out
+            report = ReportConsole(results)
+            report.generate()
+            output = out.getvalue().strip()
+            lines = output.split("\n")
+            self.assertEqual(len(lines), 16)
+            self.assertRegexpMatches(lines[9], r"Final Verdict.*PASS", lines[9])
+            self.assertRegexpMatches(lines[10], r"count.*2", lines[10])
+            self.assertRegexpMatches(lines[11], r"passrate.*100.00 \%", lines[11])
+        finally:
+            sys.stdout = saved_stdout
+
     def test_reportconsole_multiple_results(self):  # pylint: disable=invalid-name
         saved_stdout = sys.stdout
         results = ResultList()
@@ -114,7 +133,7 @@ class ReportCase(unittest.TestCase):
             lines = output.split("\n")
             self.assertEqual(len(lines), 14)
             self.assertRegexpMatches(lines[3], r"skip.*Skip_reason")
-            self.assertRegexpMatches(lines[8], r"Final Verdict.*PASS", lines[8])
+            self.assertRegexpMatches(lines[8], r"Final Verdict.*INCONCLUSIVE", lines[8])
             self.assertRegexpMatches(lines[9], r"count.*1", lines[9])
             self.assertRegexpMatches(lines[10], r"passrate.*0.00 \%", lines[10])
             self.assertRegexpMatches(lines[11], r"skip.*1", lines[10])


### PR DESCRIPTION
## Status
**READY**

## Description
Changed the way console reporter show the case where all tc:s in the run were skipped. This case should now be reported as inconclusive rather than pass. No exit codes were changed and no changes were done to other reports.

## Todos
- [x] Tests