### PR TITLE
Update jsonschema reqs to match jsonmerge reqs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ INSTALL_REQUIRES = [
     "yattag",
     "pyserial>2.5",
     "jsonmerge",
-    "jsonschema",
+    "jsonschema<3.0.0",
     "mbed-ls>=1.5.1,==1.*",
     "semver",
     "mbed-flasher==0.9.*",


### PR DESCRIPTION
## Status
**READY**

## Description
A new version of jsonschema was released and it breaks compatibility with jsonmerge. 