### PR TITLE
Let's use power switch to enable ports in e2e tests.

### DIFF
--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -251,6 +251,7 @@ def runWinHwTests(){
 
     setBuildStatus('PENDING', "${buildName}", 'start')
     try {
+        bat "c:\\32a31_ykushcmd_rev1.1.0\\ykushcmd\\bin\\ykushcmd.exe -u a"
         stage("${buildName}") {
             bat """
                 virtualenv --python=c:\\Python27\\python.exe py2venv --no-site-packages || goto :error


### PR DESCRIPTION
## Status
**READY**

## Description
In our E2E tests it's possible that sometimes the power switch switches certain ports offline, which causes issues in tests. This PR should re-enable all ports when tests start.