### PR TITLE
Allow disabling storing received lines in memory to Dut

### DIFF
--- a/doc-source/tc_api.rst
+++ b/doc-source/tc_api.rst
@@ -308,6 +308,10 @@ this returns the serial port name or path
 (eg. COM0 or /dev/ttyACM0).
 Please note only local device has this comport usage.
 
+**store_traces**
+This property (boolean) controls storing received lines for a dut. If this is set to True (default), all lines the dut receives are stored in memory in an internal list called traces.
+If set to False, no lines will be stored. This also affects lines related to CliResponse objects, so command response objects will not have lines stored in them either.
+
 *******************************
 Command and response public API
 *******************************

--- a/doc/tc_api.md
+++ b/doc/tc_api.md
@@ -273,6 +273,10 @@ this returns the serial port name or path
 (eg. COM0 or /dev/ttyACM0).
 Please note only local device has this comport usage.
 
+**store_traces**
+This property (boolean) controls storing received lines for a dut. If this is set to True (default), all lines the dut receives are stored in memory in an internal list called traces.
+If set to False, no lines will be stored. This also affects lines related to CliResponse objects, so command response objects will not have lines stored in them either.
+
 ## Command and response public API
 The testcase superclass Bench contains
 a command api that can be used to send commands to the DUT.

--- a/test/test_dut.py
+++ b/test/test_dut.py
@@ -19,13 +19,14 @@ import unittest
 
 import mock
 
+from icetea_lib.CliResponse import CliResponse
 from icetea_lib.DeviceConnectors.Dut import Dut
 from icetea_lib.TestStepError import TestStepError, TestStepTimeout
 
 
+@mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
 class DutTestcase(unittest.TestCase):
 
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
     def test_executionready_wait_skip(self, mock_log):  # pylint: disable=unused-argument
         dut = Dut("test_dut")
         with mock.patch.object(dut, "response_received") as mock_r:
@@ -43,7 +44,6 @@ class DutTestcase(unittest.TestCase):
             with self.assertRaises(TestStepError):
                 dut._wait_for_exec_ready()  # pylint: disable=protected-access
 
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
     def test_execready_wait_timeout(self, mock_log):  # pylint: disable=unused-argument
         dut = Dut("test_dut")
         with mock.patch.object(dut, "response_received") as mock_r:
@@ -55,7 +55,6 @@ class DutTestcase(unittest.TestCase):
                 with self.assertRaises(TestStepTimeout):
                     dut._wait_for_exec_ready()  # pylint: disable=protected-access
 
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
     def test_initclihuman(self, mock_log):  # pylint: disable=unused-argument
         dut = Dut("test_Dut")
         with mock.patch.object(dut, "execute_command") as m_com:
@@ -76,6 +75,51 @@ class DutTestcase(unittest.TestCase):
             self.assertListEqual(dut.post_cli_cmds, [["com1", True, False]])
             self.assertEqual(len(m_com.mock_calls), 1)
             m_com.assert_called_once_with("com1", wait=False, asynchronous=True)
+
+    def test_dut_run(self, mock_log):
+        dut = Dut("test_Dut")
+        type(dut)._logger = mock.MagicMock()
+        dut.logger = mock.MagicMock()
+        semaphore = mock.MagicMock()
+        semaphore.acquire = mock.MagicMock(side_effect=[True, Exception])
+
+        type(dut)._sem = semaphore
+        type(dut)._signalled_duts = [dut]
+        type(dut)._run = mock.MagicMock(side_effect=[True, False])
+        type(dut).waiting_for_response = mock.PropertyMock(return_value=None)
+
+        query = mock.MagicMock()
+        query.cmd = mock.MagicMock()
+        dut.query = query
+        dut.writeline = mock.MagicMock(side_effect=[Exception])
+        dut.readline = mock.MagicMock(return_value=False)
+        dut.response_received = mock.MagicMock()
+        with self.assertRaises(Exception):
+            dut.run()
+
+    def test_store_traces(self, mock_log):
+        dut = Dut("test")
+        self.assertTrue(dut.store_traces)
+        dut.store_traces = False
+        self.assertFalse(dut.store_traces)
+        dut.store_traces = True
+        self.assertTrue(dut.store_traces)
+
+    def test_read_reasponse(self, mock_log):
+        dut = Dut("test")
+        with mock.patch.object(dut, "readline") as mocked_readline:
+            mocked_readline.side_effect = ["retcode: 0", RuntimeError, "retcode: 0", "test"]
+            resp = dut._read_response()
+            self.assertTrue(isinstance(resp, CliResponse))
+            self.assertEqual(dut._read_response(), -1)
+            prior_len = len(dut.traces)
+            dut.store_traces = False
+            dut._read_response()
+            self.assertEqual(len(dut.traces), prior_len)
+            dut.store_traces = True
+            resp = dut._read_response()
+            self.assertEqual(len(dut.traces), prior_len + 1)
+            self.assertIsNone(resp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Status
**READY**

## Description
Allow users to disable storing lines to each dut if they wish to run very long duration testing and they don't care about received lines as much.

## Todos
- [x] Tests
- [x] Documentation

## Impacted Areas in Application
* Dut object