### PR TITLE
Split DutMbed from DutSerial. Support generic serial duts.

### DIFF
--- a/doc-source/Icetea.rst
+++ b/doc-source/Icetea.rst
@@ -53,21 +53,21 @@ Folder structure
 ****************
 
 |  /icetea> tree
-|  ├───doc         // these documents
+|  ├───doc         // these documents in md format
+|  ├───doc-source  // these documents
 |  ├───examples    // some test case examples
 |  ├───log         // test execution logs, when running Icetea directly from GIT repository root
 |  ├───icetea_lib    // Icetea -libraries
 |  │   ├───DeviceConnectors  // DUT connectors
-|  │   ├───ExtApps           // test required external modules
-|  │   ├───Extensions        // default extensions, which is loaded automatically
 |  │   ├───build             // build object implementation
 |  │   ├───Events            // Event system implementation
 |  │   ├───Reports           // Reporters
 |  │   ├───TestBench         // Test bench implementation
-|  │   ├───Plugins           // Plugin implementation and default plugins
+|  │   ├───Plugin            // Plugin implementation and default plugins
 |  │   ├───Randomize         // Random seed generator implementation
 |  │   ├───ResourceProvider  // Allocators and ResourceProvider
 |  │   ├───TestSuite         // Test runner implementation
+|  │   └───tools             // Tools
 |  └───test         // unit tests
 
 *******

--- a/doc-source/tc_api.rst
+++ b/doc-source/tc_api.rst
@@ -150,7 +150,8 @@ It can contain dictionaries under the following keys:
     * "*", dictionary, contains default requirements for all nodes
         * "count", number of duts required
         * "type", type of duts,
-          allowed values: hardware(default), process
+          allowed values: hardware(default, same as mbed), process, serial, mbed
+        * "serial_port", serial port name when type of the dut is serial.
         * "allowed_platforms", list of platforms allowed
           for this test case. If no other platform is specified
           with platform_name, first item in this list will be used.

--- a/doc/Icetea.md
+++ b/doc/Icetea.md
@@ -48,9 +48,10 @@ installed by `Icetea` installation.
 ```
 /icetea> tree
 ├───doc         // these documents
+├───doc-source  // these documents in rst format
 ├───examples    // some test case examples
 ├───log         // test execution logs, when running Icetea directly from GIT repository root
-├───icetea_lib    // Icetea -libraries
+├───icetea_lib  // Icetea -libraries
 │   ├───DeviceConnectors  // DUT connectors
 │   ├───ExtApps           // test required external modules
 │   ├───Extensions        // default extensions, which is loaded automatically
@@ -154,7 +155,7 @@ Supported cli parameters are described below:
 | --bin | Used binary for DUTs when process/hardware is used. NOTE: Does not affect duts which specify their own binaries | Valid file name or path |  |  |
 | --tc_cfg | Test case configuration file | Valid file name or path |  |  |
 | --ch | Use specific rf channel |  |  |  |
-| --type | Overrides DUT type |  |  |  |
+| --type | Overrides DUT type | hardware, process, serial or mbed |  |  |
 | --platform_name | Overides used platform. Must be found in allowed_platforms in dut configuration if allowed_platforms is defined and non-empty |  |  |  |
 | --putty | Open putty after TC executed |  |  |  |
 | --skip_setup | Skip test case setup phase |  |  |  |

--- a/doc/tc_api.md
+++ b/doc/tc_api.md
@@ -125,7 +125,8 @@ It can contain dictionaries under the following keys:
     * "*", dictionary, contains default requirements for all nodes
         * "count", number of duts required
         * "type", type of duts,
-        allowed values: hardware(default), process
+        allowed values: hardware(default, same as mbed), process, serial, mbed
+        * "serial_port": defines the serial port this dut is connected to, as a string, when using serial type dut.
         * "allowed_platforms", list of platforms allowed
         for this test case. If no other platform is specified
         with platform_name, first item in this list will be used.

--- a/examples/sample_serial.py
+++ b/examples/sample_serial.py
@@ -1,0 +1,48 @@
+"""
+Copyright 2019 ARM Limited
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# pylint: disable=missing-docstring
+
+from icetea_lib.TestBench.Bench import Bench
+
+
+class Testcase(Bench):
+    def __init__(self):
+        Bench.__init__(self,
+                       name="sample_serial",
+                       title="Example test for using serial type duts.",
+                       status="released",
+                       purpose="Act as an example of defining a serial type dut.",
+                       component=["cmdline"],
+                       type="smoke",
+                       requirements={
+                           "duts": {
+                               '*': {
+                                   "count": 1,
+                                   "type": "serial"
+                               },
+                               "1": {"serial_port": "/dev/ttyACM0"}
+                           }
+                       }
+                      )
+
+    def setup(self):
+        pass
+
+    def case(self):
+        self.command(1, "echo 'Hello World'")
+
+    def teardown(self):
+        pass

--- a/icetea_lib/Plugin/plugins/LocalAllocator/DutMbed.py
+++ b/icetea_lib/Plugin/plugins/LocalAllocator/DutMbed.py
@@ -1,0 +1,167 @@
+"""
+Copyright 2019 ARM Limited
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+DutMbed module contains the DutMbed Dut subclass.
+"""
+# pylint: disable=too-many-branches,too-many-arguments
+from prettytable import PrettyTable
+
+from icetea_lib.LogManager import get_external_logger
+from icetea_lib.Plugin.plugins.LocalAllocator.DutSerial import DutSerial
+from icetea_lib.DeviceConnectors.Dut import DutConnectionError
+from icetea_lib.build import Build
+
+try:
+    from mbed_flasher.flash import Flash
+except ImportError:
+    Flash = None
+
+try:
+    from mbed_flasher.common import FlashError
+
+    FLASHER_ERRORS = (FlashError, SyntaxError, NotImplementedError)
+except ImportError:
+    FlashError = None
+    FLASHER_ERRORS = (SyntaxError, NotImplementedError)
+
+
+class DutMbed(DutSerial):
+    """
+    DutMbed, child of DutSerial. Mbed device over serial connection.
+    """
+    def __init__(self, name='mbed', port=None, baudrate=115200, config=None,
+                 ch_mode_config=None, serial_config=None, params=None):
+        """
+        Mbed device over serial connection.
+
+        :param name: Dut name
+        :param port: Serial port name
+        :param baudrate: Baudrate, int
+        :param config: configuration dict
+        :param ch_mode_config: dict
+        :param serial_config: dict
+        :param params: dict
+        """
+        super(DutMbed, self).__init__(name, port, baudrate, config, ch_mode_config,
+                                      serial_config, params)
+
+    def flash(self, binary_location=None, forceflash=None):
+        """
+        Flash a binary to the target device using mbed-flasher.
+
+        :param binary_location: Binary to flash to device.
+        :param forceflash: Not used.
+        :return: False if an unknown error was encountered during flashing.
+        True if flasher retcode == 0
+        :raises: ImportError if mbed-flasher not installed.
+        :raises: DutConnectionError if flashing fails.
+        """
+        if not Flash:
+            self.logger.error("Mbed-flasher not installed!")
+            raise ImportError("Mbed-flasher not installed!")
+
+        try:
+            # create build object
+            self.build = Build.init(binary_location)
+        except NotImplementedError as error:
+            self.logger.error("Build initialization failed. "
+                              "Check your build location.")
+            self.logger.debug(error)
+            raise DutConnectionError(error)
+
+        # check if need to flash - depend on forceflash -option
+        if not self._flash_needed(forceflash=forceflash):
+            self.logger.info("Skipping flash, not needed.")
+            return True
+        # initialize mbed-flasher with proper logger
+        logger = get_external_logger("mbed-flasher", "FLS")
+        flasher = Flash(logger=logger)
+
+        if not self.device:
+            self.logger.error("Trying to flash device but device is not there?")
+            return False
+
+        try:
+            buildfile = self.build.get_file()
+            if not buildfile:
+                raise DutConnectionError("Binary {} not found".format(buildfile))
+            self.logger.info('Flashing dev: %s', self.device['target_id'])
+            target_id = self.device.get("target_id")
+            retcode = flasher.flash(build=buildfile, target_id=target_id,
+                                    device_mapping_table=[self.device])
+        except FLASHER_ERRORS as error:
+            if error.__class__ == NotImplementedError:
+                self.logger.error("Flashing not supported for this platform!")
+            elif error.__class__ == SyntaxError:
+                self.logger.error("target_id required by mbed-flasher!")
+            if FlashError is not None:
+                if error.__class__ == FlashError:
+                    self.logger.error("Flasher raised the following error: %s Error code: %i",
+                                      error.message, error.return_code)
+            raise DutConnectionError(error)
+        if retcode == 0:
+            self.dutinformation.build_binary_sha1 = self.build.sha1
+            return True
+        self.dutinformation.build_binary_sha1 = None
+        return False
+
+    def _flash_needed(self, **kwargs):
+        """
+        Check if flashing is needed. Flashing can be skipped if resource binary_sha1 attribute
+        matches build sha1 and forceflash is not True.
+
+        :param kwargs: Keyword arguments (forceflash: Boolean)
+        :return: Boolean
+        """
+        forceflash = kwargs.get("forceflash", False)
+        cur_binary_sha1 = self.dutinformation.build_binary_sha1
+        if not forceflash and self.build.sha1 == cur_binary_sha1:
+            return False
+        return True
+
+    def print_info(self):
+        """
+        Prints Dut information nicely formatted into a table.
+
+        :return: Nothing
+        """
+        table = PrettyTable()
+        start_string = "DutMbed {} \n".format(self.name)
+        row = []
+        info_string = ""
+        if self.config:
+            info_string = info_string + "Configuration for this DUT:\n\n {} \n".format(self.config)
+        if self.comport:
+            table.add_column("COM port", [])
+            row.append(self.comport)
+        if self.port:
+            if hasattr(self.port, "baudrate"):
+                table.add_column("Baudrate", [])
+                row.append(self.port.baudrate)
+            if hasattr(self.port, "xonxoff"):
+                table.add_column("XON/XOFF", [])
+                row.append(self.port.xonxoff)
+            if hasattr(self.port, "timeout"):
+                table.add_column("Timeout", [])
+                row.append(self.port.timeout)
+            if hasattr(self.port, "rtscts"):
+                table.add_column("RTSCTS", [])
+                row.append(self.port.rtscts)
+        if self.location:
+            table.add_column("Location", [])
+            row.append("X = {}, Y = {}".format(self.location.x_coord, self.location.y_coord))
+        self.logger.info(start_string)
+        self.logger.debug(info_string)
+        table.add_row(row)
+        print(table)

--- a/icetea_lib/Plugin/plugins/LocalAllocator/DutSerial.py
+++ b/icetea_lib/Plugin/plugins/LocalAllocator/DutSerial.py
@@ -19,7 +19,7 @@ serial and chunk mode parameters.
 # Disable too many arguments warning and string statement has no effect warning
 # Disable Too few public methods warning, too many public methods warning
 # pylint: disable=R0913,W0105,R0903,R0904
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes,unused-argument
 
 import time
 from collections import deque
@@ -29,22 +29,8 @@ from prettytable import PrettyTable
 
 from icetea_lib.DeviceConnectors.Dut import Dut, DutConnectionError
 from icetea_lib.enhancedserial import EnhancedSerial
-from icetea_lib.tools.tools import strip_escape, split_by_n, getargspec
+from icetea_lib.tools.tools import strip_escape, split_by_n
 from icetea_lib.DeviceConnectors.DutInformation import DutInformation
-from icetea_lib.build.build import Build
-from icetea_lib.LogManager import get_external_logger
-
-try:
-    from mbed_flasher.flash import Flash
-except ImportError:
-    Flash = None
-
-try:
-    from mbed_flasher.common import FlashError
-    FLASHER_ERRORS = (NotImplementedError, SyntaxError, FlashError)
-except ImportError:
-    FlashError = None
-    FLASHER_ERRORS = (NotImplementedError, SyntaxError)
 
 
 class SerialParams(object):
@@ -111,7 +97,7 @@ class DutSerial(Dut):
                                                                               0.01),
                                                start_delay=ch_mode_config.get("ch_mode_start_delay",
                                                                               0))
-        self.input_queue = deque() # Input queue
+        self.input_queue = deque()  # Input queue
         self.daemon = True  # Allow Python to stop us
         self.keep_reading = False
 
@@ -128,8 +114,9 @@ class DutSerial(Dut):
                 post_cli_cmds = config["application"]["post_cli_cmds"]
             if post_cli_cmds is not None:
                 self.set_post_cli_cmds(post_cli_cmds)
-        self.dutinformation = DutInformation("unknown",
-                                             self.config.get('allocated').get('target_id'),
+        tid = self.config.get('allocated', {}).get('target_id', "unknown")
+        self.dutinformation = DutInformation("serial",
+                                             tid,
                                              index=self.index, build=self.build)
 
     """Properties"""
@@ -240,70 +227,12 @@ class DutSerial(Dut):
         """
         return self.config.get('allocated').get('target_id')
 
-    def flash(self, binary, forceflash=None):  # pylint: disable=too-many-branches
+    def flash(self, binary_location=None, forceflash=None):  # pylint: disable=too-many-branches
         """
-        Flash a binary to the target device using mbed-flasher.
-
-        :param binary: Binary to flash to device
-        :param forceflash: Boolean
-        :return: False if an error was encountered during flashing. True if flasher retcode == 0
-        :raises: ImportError if mbed-flasher not installed.
-        :raises: DutConnectionError if Build initialization fails (binary not found usually).
+        Nothing, not implemented.
         """
-        error_occured = False
-        if Flash is None:
-            self.logger.warning("mbed-flasher not installed. "
-                                "(https://github.com/ARMmbed/mbed-flasher)")
-            raise ImportError("Mbed-flasher not installed.")
-
-        try:
-            # Create build object.
-            self.build = Build.init(binary)
-        except NotImplementedError as error:
-            self.logger.error("Build initialization failed. Check your build location.")
-            self.logger.debug(error)
-            raise DutConnectionError(error)
-
-        # Check if flashing is needed. Depends on forceflash-option.
-        if not self._flash_needed(forceflash=forceflash):
-            self.logger.info("Skipping flash, not needed.")
-            return True
-
-        if "logger" in getargspec(Flash.__init__).args:
-            # get_resourceprovider_logger returns previous logger if one already exists.
-            # If no logger with name mbed-flasher exists, a new one is created.
-            logger = get_external_logger("mbed-flasher", "FLS")
-            flasher = Flash(logger=logger)
-        else:
-            # Backwards compatibility for older mbed-flasher versions.
-            flasher = Flash()
-        retcode = None
-        try:
-            if self.device:
-                buildfile = self.build.get_file()
-                if not buildfile:
-                    raise DutConnectionError("Binary {} not found".format(buildfile))
-                self.logger.info('Flashing dev: %s', self.device['target_id'])
-                target_id = self.device.get("target_id")
-                retcode = flasher.flash(build=buildfile, target_id=target_id,
-                                        device_mapping_table=[self.device])
-            else:
-                error_occured = True
-        except FLASHER_ERRORS as error:
-            if error.__class__ == NotImplementedError:
-                self.logger.error("Flashing not supported for this platform!")
-            elif error.__class__ == SyntaxError:
-                self.logger.error("target_id required by mbed-flasher!")
-            if FlashError is not None:
-                if error.__class__ == FlashError:
-                    self.logger.error("Flasher raised the following error: %s Error code: %i",
-                                      error.message, error.return_code)
-            raise DutConnectionError(error)
-        if retcode != 0:
-            error_occured = True
-        else:
-            self.dutinformation.build_binary_sha1 = self.build.sha1
-        return not error_occured
+        self.logger.warning("Flashing is not supported for this dut type.")
+        return True
 
     def get_info(self):
         """
@@ -453,7 +382,7 @@ class DutSerial(Dut):
                 self.port.write((data + "\n").encode())
         except SerialException as err:
             self.logger.exception("SerialError occured while trying to write data {}.".format(data))
-            raise IOError(str(err))
+            raise RuntimeError(str(err))
 
     # read line from serial port
     def _readline(self, timeout=1):
@@ -563,8 +492,4 @@ class DutSerial(Dut):
         :param kwargs: Keyword arguments (forceflash: Boolean)
         :return: Boolean
         """
-        forceflash = kwargs.get("forceflash", False)
-        cur_binary_sha1 = self.dutinformation.build_binary_sha1
-        if not forceflash and self.build.sha1 == cur_binary_sha1:
-            return False
-        return True
+        return False

--- a/icetea_lib/Plugin/plugins/LocalAllocator/LocalAllocator.py
+++ b/icetea_lib/Plugin/plugins/LocalAllocator/LocalAllocator.py
@@ -14,7 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-
 LocalAllocator module. Implements allocating local resources using mbedls
 """
 
@@ -30,9 +29,50 @@ from icetea_lib.Plugin.plugins.LocalAllocator.DutDetection import DutDetection
 from icetea_lib.Plugin.plugins.LocalAllocator.DutConsole import DutConsole
 from icetea_lib.Plugin.plugins.LocalAllocator.DutProcess import DutProcess
 from icetea_lib.Plugin.plugins.LocalAllocator.DutSerial import DutSerial
+from icetea_lib.Plugin.plugins.LocalAllocator.DutMbed import DutMbed
 
 
-def init_hardware_dut(contextlist, conf, index, args):
+def init_generic_serial_dut(contextlist, conf, index, args):
+    """
+    Initializes a local hardware dut
+    """
+    port = conf['serial_port']
+    baudrate = (args.baudrate if args.baudrate else conf.get(
+        "application", {}).get("baudrate", 115200))
+    serial_config = {}
+    if args.serial_rtscts:
+        serial_config["serial_rtscts"] = args.serial_rtscts
+    elif args.serial_xonxoff:
+        serial_config["serial_xonxoff"] = args.serial_xonxoff
+
+    if args.serial_timeout:
+        serial_config["serial_timeout"] = args.serial_timeout
+
+    ch_mode_config = {}
+    if args.serial_ch_size > 0:
+        ch_mode_config["ch_mode"] = True
+        ch_mode_config["ch_mode_chunk_size"] = args.serial_ch_size
+    elif args.serial_ch_size is 0:
+        ch_mode_config["ch_mode"] = False
+
+    if args.ch_mode_ch_delay:
+        ch_mode_config["ch_mode_ch_delay"] = args.ch_mode_ch_delay
+    dut = DutSerial(name="D%d" % index, port=port, baudrate=baudrate,
+                    config=conf, ch_mode_config=ch_mode_config,
+                    serial_config=serial_config, params=args)
+    dut.index = index
+
+    dut.platform = conf.get("platform_name", "serial")
+
+    msg = 'Use device in serial port {} as D{}'
+    contextlist.logger.info(msg.format(port,
+                                       index))
+
+    contextlist.duts.append(dut)
+    contextlist.dutinformations.append(dut.get_info())
+
+
+def init_mbed_dut(contextlist, conf, index, args):
     """
     Initializes a local hardware dut
     """
@@ -68,9 +108,9 @@ def init_hardware_dut(contextlist, conf, index, args):
     if args.ch_mode_ch_delay:
         ch_mode_config["ch_mode_ch_delay"] = args.ch_mode_ch_delay
 
-    dut = DutSerial(name="D%d" % index, port=port, baudrate=baudrate,
-                    config=conf, ch_mode_config=ch_mode_config,
-                    serial_config=serial_config, params=args)
+    dut = DutMbed(name="D%d" % index, port=port, baudrate=baudrate,
+                  config=conf, ch_mode_config=ch_mode_config,
+                  serial_config=serial_config, params=args)
     dut.index = index
 
     # If something to flash, get the allocated device and flash it
@@ -78,7 +118,7 @@ def init_hardware_dut(contextlist, conf, index, args):
         if contextlist.check_flashing_need('hardware',
                                            binary,
                                            args.forceflash):
-            if dut.flash(binary=binary, forceflash=args.forceflash):
+            if dut.flash(binary_location=binary, forceflash=args.forceflash):
                 contextlist.logger.info('flash ready')
             else:
                 dut.close_dut(False)
@@ -178,7 +218,7 @@ class LocalAllocator(BaseAllocator):
         :return: True if type is supported, False otherwise
         """
         try:
-            return dut_configuration["type"] in ["hardware", "process"]
+            return dut_configuration["type"] in ["hardware", "process", "serial", "mbed"]
         except KeyError:
             return False
 
@@ -206,7 +246,7 @@ class LocalAllocator(BaseAllocator):
             for dut_config in dut_config_list:
                 if not self.can_allocate(dut_config.get_requirements()):
                     raise AllocationError("Resource type is not supported")
-                self._allocate(dut_config.get_requirements())
+                self._allocate(dut_config)
         except AllocationError:
             # Locally allocated don't need to be released any way for
             # now, so just re-raise the error
@@ -214,38 +254,44 @@ class LocalAllocator(BaseAllocator):
         alloc_list = AllocationContextList()
         res_id = None
         for conf in dut_config_list:
-            if conf.get("type") == "hardware":
+            if conf.get("type") == "mbed":
                 res_id = conf.get("allocated").get("target_id")
             context = AllocationContext(resource_id=res_id, alloc_data=conf)
             alloc_list.append(context)
 
-        alloc_list.set_dut_init_function("hardware", init_hardware_dut)
+        alloc_list.set_dut_init_function("serial", init_generic_serial_dut)
         alloc_list.set_dut_init_function("process", init_process_dut)
+        alloc_list.set_dut_init_function("mbed", init_mbed_dut)
 
         return alloc_list
 
     def release(self, dut=None):
         """
-        Resource releasing is not necessary. Not implemented
+        Resource releasing is not necessary. Not implemented.
+
         :param dut: Not used
         :return: Nothing
         """
         pass
 
-    def _allocate(self, dut_configuration):
+    def _allocate(self, dut_configuration):  # pylint: disable=too-many-branches
         """
-        Internal allocation function. Allocates a single resource based on dut_configuration
-        :param dut_configuration: Dictionary which describes a required resource
+        Internal allocation function. Allocates a single resource based on dut_configuration.
+
+        :param dut_configuration: ResourceRequirements object which describes a required resource
         :return: True
         :raises: AllocationError if suitable resource was not found or if the platform was not
         allowed to be used.
         """
         if dut_configuration["type"] == "hardware":
+            dut_configuration.set("type", "mbed")
+        if dut_configuration["type"] == "mbed":
             if not self._available_devices:
                 raise AllocationError("No available devices to allocate from")
-            platforms = None if 'allowed_platforms' not in dut_configuration else dut_configuration[
+            dut_reqs = dut_configuration.get_requirements()
+            platforms = None if 'allowed_platforms' not in dut_reqs else dut_reqs[
                 'allowed_platforms']
-            platform_name = None if 'platform_name' not in dut_configuration else dut_configuration[
+            platform_name = None if 'platform_name' not in dut_reqs else dut_reqs[
                 "platform_name"]
             if platform_name is None and platforms:
                 platform_name = platforms[0]
@@ -266,7 +312,7 @@ class LocalAllocator(BaseAllocator):
 
                 if DutDetection.is_port_usable(dev['serial_port']):
                     dev['state'] = "allocated"
-                    dut_configuration['allocated'] = dev
+                    dut_reqs['allocated'] = dev
                     self.logger.info("Allocated device %s", dev['target_id'])
                     return True
                 else:
@@ -274,6 +320,12 @@ class LocalAllocator(BaseAllocator):
                                      "allocated device %s", dev['serial_port'], dev['target_id'])
             # Didn't find a matching device to allocate so allocation failed
             raise AllocationError("No suitable local device available")
+        elif dut_configuration["type"] == "serial":
+            dut_reqs = dut_configuration.get_requirements()
+            if not dut_reqs.get("serial_port"):
+                raise AllocationError("Serial port not defined for requirement {}".format(dut_reqs))
+            if not DutDetection.is_port_usable(dut_reqs['serial_port']):
+                raise AllocationError("Serial port {} not usable".format(dut_reqs['serial_port']))
         # Successful allocation, return True
 
         return True

--- a/icetea_lib/Plugin/plugins/plugin_tests/test_dutmbed.py
+++ b/icetea_lib/Plugin/plugins/plugin_tests/test_dutmbed.py
@@ -1,0 +1,135 @@
+"""
+Copyright 2019 ARM Limited
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# pylint: disable=missing-docstring,unused-argument,too-many-arguments,no-self-use
+# pylint: disable=too-few-public-methods,invalid-name
+
+import unittest
+
+import mock
+
+from icetea_lib.Plugin.plugins.LocalAllocator.DutMbed import DutMbed
+from icetea_lib.DeviceConnectors.Dut import DutConnectionError
+
+try:
+    from mbed_flasher.common import FlashError
+except ImportError:
+    FlashError = None
+
+
+class MockArgspec(object):
+    def __init__(self, lst):
+        self.args = lst
+
+
+class DutMbedTestcase(unittest.TestCase):
+
+    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.get_external_logger")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Flash")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Build")
+    def test_flasher_logger_insert(self, mock_build, mock_flasher, mocked_logger, mock_logman):
+        mocked_logger_for_flasher = mock.MagicMock()
+        mocked_logger.return_value = mocked_logger_for_flasher
+        dut = DutMbed(port="test",
+                      config={"allocated": {"target_id": "thing"}, "application": "thing"})
+        dut.flash("this_is_not_a_binary")
+        mock_flasher.assert_called_with(logger=mocked_logger_for_flasher)
+
+    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.get_external_logger")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Flash")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Build")
+    def test_flash_build_init_not_implemented(self, mock_build, mock_flasher, mocked_logger,
+                                              mock_logman):
+        mock_build.init = mock.MagicMock(side_effect=[NotImplementedError])
+        mocked_logger_for_flasher = mock.MagicMock()
+        mocked_logger.return_value = mocked_logger_for_flasher
+        dut = DutMbed(port="test",
+                      config={"allocated": {"target_id": "thing"}, "application": "thing"})
+        with self.assertRaises(DutConnectionError):
+            dut.flash("try")
+
+    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.get_external_logger")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Flash")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Build")
+    def test_flash_build_get_file_fail(self, mock_build, mock_flasher, mocked_logger,
+                                       mock_logman):
+        mock_build_object = mock.MagicMock()
+        mock_build_object.get_file = mock.MagicMock(side_effect=[False, "Thisbin"])
+        mock_build.init = mock.MagicMock(return_value=mock_build_object)
+        mocked_logger_for_flasher = mock.MagicMock()
+        mocked_logger.return_value = mocked_logger_for_flasher
+        dut = DutMbed(port="test",
+                      config={"allocated": {"target_id": "thing"}, "application": "thing"})
+        with self.assertRaises(DutConnectionError):
+            dut.flash("try")
+
+    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.get_external_logger")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Flash")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Build")
+    def test_flash_fails(self, mock_build, mock_flasher, mocked_logger, mock_logman):
+        mock_build_object = mock.MagicMock()
+        mock_build_object.get_file = mock.MagicMock(return_value="Thisbin")
+        mock_build.init = mock.MagicMock(return_value=mock_build_object)
+        mocked_logger_for_flasher = mock.MagicMock()
+        mocked_logger.return_value = mocked_logger_for_flasher
+        mock_flasher_object = mock.MagicMock()
+        mock_flasher.return_value = mock_flasher_object
+        mock_flasher_object.flash = mock.MagicMock()
+        mock_flasher_object.flash.side_effect = [NotImplementedError, SyntaxError, 1]
+        if FlashError is not None:
+            mock_flasher_object.flash.side_effect = [NotImplementedError, SyntaxError, 1,
+                                                     FlashError("Error", 10)]
+        dut = DutMbed(port="test",
+                      config={"allocated": {"target_id": "thing"}, "application": "thing"})
+        with self.assertRaises(DutConnectionError):
+            dut.flash("try")
+        with self.assertRaises(DutConnectionError):
+            dut.flash("try2")
+        self.assertFalse(dut.flash("try3"))
+        if FlashError is not None:
+            with self.assertRaises(DutConnectionError):
+                dut.flash("try4")
+
+    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.get_external_logger")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Flash")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutMbed.Build")
+    def test_flash_skip_flash(self, mock_build, mock_flasher, mocked_logger, mock_logman):
+        mock_build_object = mock.MagicMock()
+        mock_build_object.get_file = mock.MagicMock(return_value="Thisbin")
+        mock_build.init = mock.MagicMock(return_value=mock_build_object)
+        mocked_logger_for_flasher = mock.MagicMock()
+        mocked_logger.return_value = mocked_logger_for_flasher
+        mock_flasher_object = mock.MagicMock()
+        mock_flasher.return_value = mock_flasher_object
+        mock_flasher_object.flash = mock.MagicMock()
+        mock_flasher_object.flash.return_value = 0
+        dut = DutMbed(port="test",
+                      config={"allocated": {"target_id": "thing"},
+                              "application": "thing"})
+        self.assertTrue(dut.flash("try"))
+        self.assertTrue(dut.flash("try"))
+        self.assertTrue(dut.flash("try"))
+        self.assertEqual(mock_flasher_object.flash.call_count, 1)
+        self.assertTrue(dut.flash("try", forceflash=True))
+        self.assertEqual(mock_flasher_object.flash.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/icetea_lib/Plugin/plugins/plugin_tests/test_dutserial.py
+++ b/icetea_lib/Plugin/plugins/plugin_tests/test_dutserial.py
@@ -1,5 +1,4 @@
-# pylint: disable=unused-argument,missing-docstring,too-many-arguments,too-few-public-methods
-# pylint: disable=no-self-use,protected-access,invalid-name
+# pylint: disable=unused-argument,invalid-name,missing-docstring,no-self-use
 
 """
 Copyright 2017 ARM Limited
@@ -14,172 +13,145 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+# pylint: disable=unused-argument,invalid-name,missing-docstring,no-self-use
+
 import unittest
 import mock
+from serial import SerialException
 
 from icetea_lib.Plugin.plugins.LocalAllocator.DutSerial import DutSerial
 from icetea_lib.DeviceConnectors.Dut import DutConnectionError
-
-try:
-    from mbed_flasher.common import FlashError
-except ImportError:
-    FlashError = None
+from icetea_lib.DeviceConnectors.DutInformation import DutInformation
 
 
-class MockArgspec(object):
-    def __init__(self, lst):
-        self.args = lst
-
-
+@mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager")
 class DutSerialTestcase(unittest.TestCase):
 
-    # Mock base class
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager.get_bench_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.getargspec")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.get_external_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Flash")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Build")
-    def test_flasher_logger_insert(self, mock_build, mock_flasher, mocked_logger, mock_inspect,
-                                   mock_bench_logger):
-        mock_inspect.return_value = MockArgspec(["logger"])
-        mocked_logger_for_flasher = mock.MagicMock()
-        mocked_logger.return_value = mocked_logger_for_flasher
-        dut = DutSerial(port="test",
-                        config={"allocated": {"target_id": "thing"}, "application": "thing"})
-        dut.flash("this_is_not_a_binary")
-        mock_flasher.assert_called_with(logger=mocked_logger_for_flasher)
+    def test_properties(self, mock_logger):
+        ds = DutSerial()
+        self.assertFalse(ds.ch_mode)
+        ds.ch_mode = True
+        self.assertTrue(ds.ch_mode)
 
-        mock_flasher.reset_mock()
-        mock_inspect.return_value = MockArgspec([])
-        dut = DutSerial(port="test",
-                        config={"allocated": {"target_id": "thing"}, "application": "thing"})
-        dut.flash("this_is_not_a_binary")
-        mock_flasher.assert_called_with()
+        self.assertEqual(ds.ch_mode_chunk_size, 1)
+        ds.ch_mode_chunk_size = 2
+        self.assertEqual(ds.ch_mode_chunk_size, 2)
 
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager.get_bench_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.getargspec")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.get_external_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Flash")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Build")
-    def test_flash_build_init_not_implemented(self, mock_build, mock_flasher, mocked_logger,
-                                              mock_inspect, mock_bench_logger):
-        mock_build.init = mock.MagicMock(side_effect=[NotImplementedError])
-        mock_inspect.return_value = MockArgspec(["logger"])
-        mocked_logger_for_flasher = mock.MagicMock()
-        mocked_logger.return_value = mocked_logger_for_flasher
-        dut = DutSerial(port="test",
-                        config={"allocated": {"target_id": "thing"}, "application": "thing"})
+        self.assertEqual(ds.ch_mode_ch_delay, 0.01)
+        ds.ch_mode_ch_delay = 0.02
+        self.assertEqual(ds.ch_mode_ch_delay, 0.02)
+
+        self.assertEqual(ds.ch_mode_start_delay, 0)
+        ds.ch_mode_start_delay = 1
+        self.assertEqual(ds.ch_mode_start_delay, 1)
+
+        self.assertEqual(ds.serial_baudrate, 460800)
+        ds.serial_baudrate = 9600
+        self.assertEqual(ds.serial_baudrate, 9600)
+
+        self.assertEqual(ds.serial_timeout, 0.01)
+        ds.serial_timeout = 0.02
+        self.assertEqual(ds.serial_timeout, 0.02)
+
+        self.assertFalse(ds.serial_xonxoff)
+        ds.serial_xonxoff = True
+        self.assertTrue(ds.serial_xonxoff)
+
+        self.assertFalse(ds.serial_rtscts)
+        ds.serial_rtscts = True
+        self.assertTrue(ds.serial_rtscts)
+
+    def test_get_resource_id(self, mock_logger):
+        ds = DutSerial(config={"allocated": {"target_id": "test"}, "application": {}})
+        self.assertEqual(ds.get_resource_id(), "test")
+
+    def test_get_info(self, mock_logger):
+        ds = DutSerial()
+        info = ds.get_info()
+        self.assertTrue(isinstance(info, DutInformation))
+
+    def test_flash(self, mock_logger):
+        ds = DutSerial()
+        self.assertTrue(ds.flash())
+
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.EnhancedSerial")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Thread")
+    def test_open_connection(self, mock_thread, mock_es, mock_logger):
+        ds = DutSerial()
+        ds.readthread = 1
+        ds.params = mock.MagicMock()
+        type(ds.params).reset = mock.PropertyMock(return_value=False)
         with self.assertRaises(DutConnectionError):
-            dut.flash("try")
-
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager.get_bench_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.getargspec")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.get_external_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Flash")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Build")
-    def test_flash_build_get_file_fail(self, mock_build, mock_flasher, mocked_logger, mock_inspect,
-                                       mock_bench_logger):
-        mock_build_object = mock.MagicMock()
-        mock_build_object.get_file = mock.MagicMock(side_effect=[False, "Thisbin"])
-        mock_build.init = mock.MagicMock(return_value=mock_build_object)
-        mock_inspect.return_value = MockArgspec(["logger"])
-        mocked_logger_for_flasher = mock.MagicMock()
-        mocked_logger.return_value = mocked_logger_for_flasher
-        dut = DutSerial(port="test",
-                        config={"allocated": {"target_id": "thing"}, "application": "thing"})
+            ds.open_connection()
+        ds.readthread = None
+        mock_es_2 = mock.MagicMock()
+        mock_es_2.flushInput = mock.MagicMock(side_effect=[SerialException, ValueError, 1])
+        mock_es.return_value = mock_es_2
         with self.assertRaises(DutConnectionError):
-            dut.flash("try")
+            ds.open_connection()
+        with self.assertRaises(ValueError):
+            ds.open_connection()
+        ds.open_connection()
+        mock_thread.assert_called_once()
 
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager.get_bench_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.getargspec")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.get_external_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Flash")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Build")
-    def test_flash_fails(self, mock_build, mock_flasher, mocked_logger, mock_inspect,
-                         mock_bench_logger):
-        mock_build_object = mock.MagicMock()
-        mock_build_object.get_file = mock.MagicMock(return_value="Thisbin")
-        mock_build.init = mock.MagicMock(return_value=mock_build_object)
-        mock_inspect.return_value = MockArgspec(["logger"])
-        mocked_logger_for_flasher = mock.MagicMock()
-        mocked_logger.return_value = mocked_logger_for_flasher
-        mock_flasher_object = mock.MagicMock()
-        mock_flasher.return_value = mock_flasher_object
-        mock_flasher_object.flash = mock.MagicMock()
-        mock_flasher_object.flash.side_effect = [NotImplementedError, SyntaxError, 1]
-        if FlashError is not None:
-            mock_flasher_object.flash.side_effect = [NotImplementedError, SyntaxError, 1,
-                                                     FlashError("Error", 10)]
-        dut = DutSerial(port="test",
-                        config={"allocated": {"target_id": "thing"}, "application": "thing"})
-        with self.assertRaises(DutConnectionError):
-            dut.flash("try")
-        with self.assertRaises(DutConnectionError):
-            dut.flash("try2")
-        self.assertFalse(dut.flash("try3"))
-        if FlashError is not None:
-            with self.assertRaises(DutConnectionError):
-                dut.flash("try4")
+    def test_prepare_connection_close(self, mock_logger):
+        ds = DutSerial()
+        with mock.patch.object(ds, "init_cli_human") as mock_init_cli_human:
+            with mock.patch.object(ds, "stop") as mock_stop:
+                ds.prepare_connection_close()
+                mock_init_cli_human.assert_called_once()
+                mock_stop.assert_called_once()
 
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager.get_bench_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.getargspec")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.get_external_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Flash")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Build")
-    def test_flash_skip_flash(self, mock_build, mock_flasher, mocked_logger, mock_inspect,
-                              mock_bench_logger):
-        mock_build_object = mock.MagicMock()
-        mock_build_object.get_file = mock.MagicMock(return_value="Thisbin")
-        mock_build.init = mock.MagicMock(return_value=mock_build_object)
-        mock_inspect.return_value = MockArgspec(["logger"])
-        mock_logger_for_flasher = mock.MagicMock()
-        mocked_logger.return_value = mock_logger_for_flasher
-        mock_flasher_object = mock.MagicMock()
-        mock_flasher.return_value = mock_flasher_object
-        mock_flasher_object.flash = mock.MagicMock()
-        mock_flasher_object.flash.return_value = 0
-        dut = DutSerial(port="test", config={
-            "allocated": {"target_id": "thing"},
-            "application": "thing"
-        })
-        self.assertTrue(dut.flash("try"))
-        self.assertTrue(dut.flash("try"))
-        self.assertTrue(dut.flash("try"))
-        self.assertEqual(mock_flasher_object.flash.call_count, 1)
-        self.assertTrue(dut.flash("try", forceflash=True))
-        self.assertEqual(mock_flasher_object.flash.call_count, 2)
+    def test_close_connection(self, mock_logger):
+        ds = DutSerial()
+        mocked_port = mock.MagicMock()
+        mocked_port.close = mock.MagicMock()
+        ds.port = mocked_port
+        with mock.patch.object(ds, "stop") as mock_stop:
+            ds.close_connection()
+            mock_stop.assert_called_once()
+            mocked_port.close.assert_called_once()
+            self.assertFalse(ds.port)
 
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager.get_bench_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.getargspec")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.get_external_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Flash")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Build")
-    def test_peek(self, mock_build, mock_flasher, mocked_logger, mock_inspect,
-                  mock_bench_logger):
-        dut = DutSerial(port="test", config={
-            "allocated": {"target_id": "thing"},
-            "application": "thing"
-        })
-        dut.port = mock.MagicMock()
-        dut.port.peek = mock.MagicMock(return_value="test")
-        self.assertEqual(dut.peek(), "test")
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.time")
+    def test_reset(self, mocked_time, mock_logger):
+        ds = DutSerial()
+        mock_port = mock.MagicMock()
+        mock_port.safe_sendBreak = mock.MagicMock(return_value=True)
+        mocked_time.sleep = mock.MagicMock()
+        ds.port = mock_port
+        self.assertIsNone(ds.reset())
 
-    @mock.patch("icetea_lib.DeviceConnectors.Dut.LogManager.get_bench_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.getargspec")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.get_external_logger")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Flash")
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.DutSerial.Build")
-    def test_readline(self, mock_build, mock_flasher, mocked_logger, mock_inspect,
-                      mock_bench_logger):
-        dut = DutSerial(port="test", config={
-            "allocated": {"target_id": "thing"},
-            "application": "thing"
-        })
-        dut.port = mock.MagicMock()
-        dut.port.readline = mock.MagicMock(side_effect=["test\n", None])
-        self.assertEqual(dut._readline(), "test")
-        self.assertIsNone(dut._readline())
+    def test_writeline(self, mock_logger):
+        ds = DutSerial()
+        mock_port = mock.MagicMock()
+        mock_port.write = mock.MagicMock(side_effect=[1, 1, 1, 1, SerialException])
+        ds.port = mock_port
+        ds.ch_mode = False
+        ds.writeline("data")
+        mock_port.write.assert_called_once_with("data\n".encode())
+        mock_port.reset_mock()
+        ds.ch_mode = True
+        ds.ch_mode_chunk_size = 2
+        ds.writeline("data")
+        mock_port.write.assert_has_calls([mock.call("da".encode()), mock.call("ta".encode()),
+                                          mock.call("\n".encode())])
+        with self.assertRaises(RuntimeError):
+            ds.writeline("data")
 
+    def test_readline(self, mock_logger):
+        ds = DutSerial()
+        ds.input_queue.append("test1")
+        read = ds.readline()
+        self.assertEqual(read, "test1")
+        self.assertIsNone(ds.readline())
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_peek(self, mock_logger):
+        ds = DutSerial()
+        mocked_port = mock.MagicMock()
+        mocked_port.peek = mock.MagicMock(return_value="test")
+        ds.port = mocked_port
+        self.assertEqual(ds.peek(), "test")
+        mocked_port.peek.assert_called_once()
+        ds.port = None
+        self.assertEqual(ds.peek(), "")

--- a/icetea_lib/Plugin/plugins/plugin_tests/test_localallocator.py
+++ b/icetea_lib/Plugin/plugins/plugin_tests/test_localallocator.py
@@ -27,7 +27,7 @@ from icetea_lib.ResourceProvider.ResourceRequirements import ResourceRequirement
 from icetea_lib.ResourceProvider.exceptions import ResourceInitError
 
 from icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator import LocalAllocator, init_process_dut
-from icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator import init_hardware_dut
+from icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator import init_mbed_dut
 
 
 @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator.DutDetection", create=False)
@@ -131,7 +131,8 @@ class TestVerify(unittest.TestCase):
         dutdetect.get_available_devices = mock.MagicMock(return_value=None)
 
         alloc = LocalAllocator()
-        self.assertRaises(AllocationError, alloc._allocate, {"type": "hardware"})
+        self.assertRaises(AllocationError, alloc._allocate,
+                          ResourceRequirements({"type": "hardware"}))
 
     def test_inter_alloc_suc_one_hardware_device_with_undef_allowed_platf(self, mock_logging,
                                                                           mock_dutdetection):
@@ -302,8 +303,8 @@ class TestVerify(unittest.TestCase):
         with self.assertRaises(ResourceInitError):
             self.assertIsNone(init_process_dut(con_list, conf, 1, mock.MagicMock()))
 
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator.DutSerial")
-    def test_init_hw_dut(self, mock_ds, mock_logging, mock_dutdetection):
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator.DutMbed")
+    def test_init_mbed_dut(self, mock_ds, mock_logging, mock_dutdetection):
         conf = {"allocated": {"serial_port": "port", "baud_rate": 115200,
                               "platform_name": "test", "target_id": "id"},
                 "application": {"bin": "binary"}}
@@ -335,15 +336,15 @@ class TestVerify(unittest.TestCase):
             mock_cfn = mock.MagicMock()
             mock_cfn.return_value = True
             mock_ds.return_value = dut1
-            init_hardware_dut(con_list, conf, 1, args)
+            init_mbed_dut(con_list, conf, 1, args)
 
             with self.assertRaises(ResourceInitError):
-                init_hardware_dut(con_list, conf, 1, args)
+                init_mbed_dut(con_list, conf, 1, args)
             dut1.close_dut.assert_called()
             dut1.close_connection.assert_called()
 
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator.DutSerial")
-    def test_init_hw_dut_skip_flash(self, mock_ds, mock_logging, mock_dutdetection):
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator.DutMbed")
+    def test_init_mbed_dut_skip_flash(self, mock_ds, mock_logging, mock_dutdetection):
         conf = {"allocated": {"serial_port": "port", "baud_rate": 115200,
                               "platform_name": "test", "target_id": "id"},
                 "application": {"bin": "binary"}}
@@ -375,11 +376,11 @@ class TestVerify(unittest.TestCase):
             mock_cfn = mock.MagicMock()
             mock_cfn.return_value = True
             mock_ds.return_value = dut1
-            init_hardware_dut(con_list, conf, 1, args)
+            init_mbed_dut(con_list, conf, 1, args)
             dut1.flash.assert_not_called()
 
-    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator.DutSerial")
-    def test_init_hw_dut_nondefault_baud_rate(self, mock_ds, mock_logging, mock_dutdetection):
+    @mock.patch("icetea_lib.Plugin.plugins.LocalAllocator.LocalAllocator.DutMbed")
+    def test_init_mbed_dut_nondefault_baud_rate(self, mock_ds, mock_logging, mock_dutdetection):
         conf = {"allocated": {"serial_port": "port", "baud_rate": 115200,
                               "platform_name": "test", "target_id": "id"},
                 "application": {"bin": "binary", "baudrate": 9600}}
@@ -413,7 +414,7 @@ class TestVerify(unittest.TestCase):
             mock_cfn = mock.MagicMock()
             mock_cfn.return_value = True
             mock_ds.return_value = dut1
-            init_hardware_dut(con_list, conf, 1, args)
+            init_mbed_dut(con_list, conf, 1, args)
             mock_ds.assert_called_once_with(baudrate=9600,
                                             ch_mode_config={'ch_mode_ch_delay': True,
                                                             'ch_mode': True,

--- a/icetea_lib/ResourceProvider/ResourceConfig.py
+++ b/icetea_lib/ResourceProvider/ResourceConfig.py
@@ -35,7 +35,7 @@ class ResourceConfig(object):  # pylint: disable=too-many-instance-attributes
         self._sim_config = None
         if self.logger is None:
             self.logger = LogManager.get_dummy_logger()
-        self._counts = {"total": 0, "hardware": 0, "process": 0}
+        self._counts = {"total": 0, "hardware": 0, "process": 0, "serial": 0, "mbed": 0}
 
     @property
     def _hardware_count(self):
@@ -44,7 +44,7 @@ class ResourceConfig(object):  # pylint: disable=too-many-instance-attributes
 
         :return: integer
         """
-        return self._counts.get("hardware")
+        return self._counts.get("hardware") + self._counts.get("serial") + self._counts.get("mbed")
 
     @_hardware_count.setter
     def _hardware_count(self, value):
@@ -261,7 +261,8 @@ class ResourceConfig(object):  # pylint: disable=too-many-instance-attributes
 
         :return: Nothing, adds results to self._hardware_count
         """
-        length = len([d for d in self._dut_requirements if d.get("type") == "hardware"])
+        length = len([d for d in self._dut_requirements if d.get("type") in ["hardware",
+                                                                             "serial", "mbed"]])
         self._hardware_count = length
 
     def count_process(self):

--- a/icetea_lib/arguments.py
+++ b/icetea_lib/arguments.py
@@ -263,7 +263,7 @@ def get_tc_arguments(parser):
                         help='Testcase Configuration file')
     group2.add_argument('--type',
                         help='Overrides DUT type.',
-                        choices=['hardware', 'process'])
+                        choices=['hardware', 'process', "serial", "mbed"])
     group2.add_argument('--platform_name',
                         help='Overrides used platform. Must be found in allowed_platforms in '
                              'dut configuration if allowed_platforms is defined and non-empty.',

--- a/icetea_lib/tc_schema.json
+++ b/icetea_lib/tc_schema.json
@@ -85,8 +85,13 @@
                                     "type": "string",
                                     "enum": [
                                         "hardware",
-                                        "process"
+                                        "process",
+                                        "serial",
+                                        "mbed"
                                     ]
+                                },
+                                "serial_port": {
+                                    "type": "string"
                                 },
                                 "allowed_platforms": {
                                     "type": "array",


### PR DESCRIPTION
## Status
**READY**

## Description
Split DutMbed from DutSerial. Enable support for generic serial duts when the serial port is defined.

## Todos
- [x] Tests
- [x] Documentation