### PR TITLE
Fixed skip_flash causing EnvironmentError when binary is not defined

### DIFF
--- a/doc-source/Icetea.rst
+++ b/doc-source/Icetea.rst
@@ -191,7 +191,7 @@ argument if they match, but the check might not be foolproof.
 --kill_putty              Kill old putty/kitty processes
 --forceflash              Force flashing of hardware devices if binary is given.                                                                                                                                                                                                              Mutually exclusive with forceflash_once
 --forceflash_once         Force flashing of hardware devices if binary is given, but only once.                                                                                                                                                                                               Mutually exclusive with forceflash
---skip_flash              Skip flashing of duts.
+--skip_flash              Skip flashing of duts.                                                                                                                                                                                                                                              Mutually exclusive with forceflash args
 --sync_start              Use echo-command to try and make sure duts have started before proceeding with test.
 ========================  ================================================================================================================================  ================================================================================================  ==============================  ==========================================
 

--- a/doc/Icetea.md
+++ b/doc/Icetea.md
@@ -183,10 +183,10 @@ Supported cli parameters are described below:
 | --serial_ch_size | Use chunk mode with size N when writing to serial port  | Integer, -1 for pre-defined mode, N=0 for normal mode, N>0 chunk mode with size N |  |  |
 | --serial_ch_delay | Use defined delay between characters. Used only when serial_ch_size > 0  | Float | 0.01 |  |
 | --kill_putty | Kill old putty/kitty processes |  |  |  |
-| --forceflash | Force flashing of hardware devices if binary is given. |  |  | Mutually exclusive with forceflash_once |
-| --forceflash_once | Force flashing of hardware devices if binary is given, but only once. |  |  | Mutually exclusive with forceflash |
+| --forceflash | Force flashing of hardware devices if binary is given. |  |  | Mutually exclusive with forceflash_once and skip_flash|
+| --forceflash_once | Force flashing of hardware devices if binary is given, but only once. |  |  | Mutually exclusive with forceflash and skip_flash |
+| --sync_start | Make sure dut applications have started using 'echo' command. | Boolean | False | Mutually exclusive with forceflash and forceflash_once. |
 | --skip_flash | Skip flashing duts. |  |  |  |
-| --sync_start | Make sure dut applications have started using 'echo' command. | Boolean | False |  |
 
 ## Running
 To run tests you first need to have the test cases in valid python modules.

--- a/icetea_lib/TestBench/BenchApi.py
+++ b/icetea_lib/TestBench/BenchApi.py
@@ -813,8 +813,7 @@ class BenchApi(object):
         """
         return self._plugins.parse_response(cmd, response)
 
-    @staticmethod
-    def _validate_dut_configs(dut_configuration_list, logger):
+    def _validate_dut_configs(self, dut_configuration_list, logger):
         """
         Validate dut configurations.
 
@@ -822,7 +821,7 @@ class BenchApi(object):
         :param logger: logger to be used
         :raises EnvironmentError if something is wrong
         """
-        return ResourceFunctions.validate_dut_configs(dut_configuration_list, logger)
+        return self._resources.validate_dut_configs(dut_configuration_list, logger)
 
     # Backwards compatibility functions here
 

--- a/icetea_lib/TestBench/Resources.py
+++ b/icetea_lib/TestBench/Resources.py
@@ -440,8 +440,7 @@ class ResourceFunctions(object):
                            "for this testcase.", len(self._duts),
                            "dut" if len(self._duts) == 1 else "duts")
 
-    @staticmethod
-    def validate_dut_configs(dut_configuration_list, logger):
+    def validate_dut_configs(self, dut_configuration_list, logger):
         """
         Validate dut configurations.
 
@@ -450,16 +449,17 @@ class ResourceFunctions(object):
         :raises EnvironmentError if something is wrong
         """
         # for now we validate only binaries - if it exists or not.
-        for conf in dut_configuration_list:
-            try:
-                binar = conf.get("application").get("bin")
-                if binar:
-                    build = Build.init(binar)
-                    if not build.is_exists():
-                        logger.warning("Binary '{}' not found".format(binar))
-                        raise EnvironmentError("Binary not found")
-            except(KeyError, AttributeError):
-                pass
+        if not self._args.skip_flash:
+            for conf in dut_configuration_list:
+                try:
+                    binar = conf.get("application").get("bin")
+                    if binar:
+                        build = Build.init(binar)
+                        if not build.is_exists():
+                            logger.warning("Binary '{}' not found".format(binar))
+                            raise EnvironmentError("Binary not found")
+                except(KeyError, AttributeError):
+                    pass
 
         if logger is not None:
             logger.debug("Configurations seems to be ok")

--- a/icetea_lib/arguments.py
+++ b/icetea_lib/arguments.py
@@ -397,17 +397,15 @@ def get_tc_arguments(parser):
                                   default=False,
                                   help='Force flashing of hardware device if '
                                        'binary is given, but only once. Defaults to False')
-
+    forceflash_group.add_argument("--skip_flash",
+                        default=False,
+                        action="store_true",
+                        help="Skip flashing hardware devices during this run.")
     group2.add_argument('--interface',
                         dest='interface',
                         default='eth0',
                         help='Network interface used in tests, unless the testcase specifies '
                              'which one to use. Defaults to eth0')
-    group2.add_argument("--skip_flash",
-                        default=False,
-                        action="store_true",
-                        help="Skip flashing hardware devices during this run.")
-
     return parser
 
 

--- a/icetea_lib/arguments.py
+++ b/icetea_lib/arguments.py
@@ -60,7 +60,6 @@ def get_base_arguments(parser):
                        default=False,
                        help='Show version')
 
-
     # Filters
     filter_group = parser.add_argument_group("Filter arguments", "Arguments used for filtering "
                                                                  "tc:s")

--- a/icetea_lib/arguments.py
+++ b/icetea_lib/arguments.py
@@ -398,9 +398,9 @@ def get_tc_arguments(parser):
                                   help='Force flashing of hardware device if '
                                        'binary is given, but only once. Defaults to False')
     forceflash_group.add_argument("--skip_flash",
-                        default=False,
-                        action="store_true",
-                        help="Skip flashing hardware devices during this run.")
+                                  default=False,
+                                  action="store_true",
+                                  help="Skip flashing hardware devices during this run.")
     group2.add_argument('--interface',
                         dest='interface',
                         default='eth0',

--- a/test/test_bench.py
+++ b/test/test_bench.py
@@ -638,25 +638,6 @@ class TestVerify(unittest.TestCase):
         self.assertEqual(testcase.run(), 0)
         self.assertFalse(testcase.get_result().skipped())
 
-    def test_config_validation_bin_not_defined(self):  # pylint: disable=invalid-name
-        duts_cfg = [{}]
-        logger = logging.getLogger('unittest')
-        logger.addHandler(logging.NullHandler())
-        self.assertEqual(Bench._validate_dut_configs(duts_cfg, logger), None)
-
-    def test_config_validation_bin_defined_but_not_exists(self):  # pylint: disable=invalid-name
-        duts_cfg = [{"application": {"bin": "not.exist"}}]
-        logger = logging.getLogger('unittest')
-        logger.addHandler(logging.NullHandler())
-        with self.assertRaises(EnvironmentError):
-            Bench._validate_dut_configs(duts_cfg, logger)
-
-    def test_config_validation_bin_defined(self):  # pylint: disable=invalid-name
-        duts_cfg = [{"application": {"bin": "./test/test_bench.py"}}]
-        logger = logging.getLogger('unittest')
-        logger.addHandler(logging.NullHandler())
-        self.assertEqual(Bench._validate_dut_configs(duts_cfg, logger), None)
-
     def test_create_new_result(self):
         test_data = dict()
         test_data["reason"] = "this is a reason"

--- a/test/test_bench_resources.py
+++ b/test/test_bench_resources.py
@@ -44,6 +44,9 @@ class MockLogger(object):
     def debug(self, *args, **kwargs):
         pass
 
+    def warning(self, *args, **kwargs):
+        pass
+
     def error(self, *args, **kwargs):
         pass
 
@@ -121,6 +124,39 @@ class ResourceMixerTests(unittest.TestCase):
         self.assertEqual(resmixer.get_dut_index("test_device"), 2)
         with self.assertRaises(ValueError):
             resmixer.get_dut_index("3")
+
+    def test_config_validation_bin_not_defined(self):  # pylint: disable=invalid-name
+        duts_cfg = [{}]
+        mocked_args = mock.MagicMock()
+        type(mocked_args).skip_flash = mock.PropertyMock(return_value=False)
+        resources = ResourceFunctions(mocked_args,
+                                      mock.MagicMock(), mock.PropertyMock(return_value=TEST_REQS))
+        self.assertEqual(resources.validate_dut_configs(duts_cfg, MockLogger()), None)
+
+    def test_config_validation_no_bin(self):
+        duts_cfg = [{"application": {"bin": "not.exist"}}]
+        mocked_args = mock.MagicMock()
+        type(mocked_args).skip_flash = mock.PropertyMock(return_value=False)
+        resources = ResourceFunctions(mocked_args, mock.MagicMock(), mock.PropertyMock(
+            return_value=TEST_REQS))
+        with self.assertRaises(EnvironmentError):
+            resources.validate_dut_configs(duts_cfg, MockLogger())
+
+    def test_config_validation_bin_defined(self):  # pylint: disable=invalid-name
+        duts_cfg = [{"application": {"bin": __file__}}]
+        mocked_args = mock.MagicMock()
+        type(mocked_args).skip_flash = mock.PropertyMock(return_value=False)
+        resources = ResourceFunctions(mocked_args,
+                                      mock.MagicMock(), mock.PropertyMock(return_value=TEST_REQS))
+        self.assertEqual(resources.validate_dut_configs(duts_cfg, MockLogger()), None)
+
+    def test_config_validation_no_bin_skip_flash(self):  # pylint: disable=invalid-name
+        duts_cfg = [{"application": {"bin": "not.exist"}}]
+        mocked_args = mock.MagicMock()
+        type(mocked_args).skip_flash = mock.PropertyMock(return_value=True)
+        resources = ResourceFunctions(mocked_args,
+                                      mock.MagicMock(), mock.PropertyMock(return_value=TEST_REQS))
+        self.assertEqual(resources.validate_dut_configs(duts_cfg, MockLogger()), None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Status
**READY**

## Description
Fixed an issue where skip_flash might cause EnvironmentError when binary was not defined.
Also made skip_flash mutually exclusive with forceflash and forceflash_once.

## Todos
- [x] Tests
- [x] Documentation

## Impacted Areas in Application
List components, applications or use-cases that this PR will affect:

* args
* Bench private API:s