### PR TITLE
Fixed 9 issues of type: PYTHON_E225 throughout 8 files in repo.

### DIFF
--- a/icetea_lib/AllocationContext.py
+++ b/icetea_lib/AllocationContext.py
@@ -387,7 +387,7 @@ class AllocationContextList(object):
                     extension_split = os.path.splitext(binary_file_name)
                     extension = extension_split[-1].lower()
                     if extension != '.bin' and extension != '.hex':
-                        self.logger.debug("File ('%s') is not supported to flash, skip it" %(
+                        self.logger.debug("File ('%s') is not supported to flash, skip it" % (
                             build_id))
                         return False
                     return True

--- a/icetea_lib/DeviceConnectors/Dut.py
+++ b/icetea_lib/DeviceConnectors/Dut.py
@@ -461,7 +461,7 @@ class Dut(object):
                     cmd = self.prev.cmd
                 else:
                     cmd = "???"
-                self.logger.error("CMD timeout: "+ cmd)
+                self.logger.error("CMD timeout: " + cmd)
                 self.query_timeout = 0
                 raise TestStepTimeout(self.name + " CMD timeout: " + cmd)
             self.logger.debug("Waiting for response... "

--- a/icetea_lib/Plugin/plugins/default_plugins.py
+++ b/icetea_lib/Plugin/plugins/default_plugins.py
@@ -20,7 +20,7 @@ from icetea_lib.Plugin.plugins.FileApi import FileApiPlugin
 from icetea_lib.Plugin.plugins.HttpApi import HttpApiPlugin
 from icetea_lib.Plugin.plugins.plugin_localallocator import LocalAllocatorPlugin
 
-default_plugins={
+default_plugins = {
     "AssertPlugin": AssertPlugin,
     "default_parsers": DefaultParsers,
     "FileApi": FileApiPlugin,

--- a/icetea_lib/bench.py
+++ b/icetea_lib/bench.py
@@ -411,7 +411,7 @@ class Bench(object):  # pylint: disable=too-many-instance-attributes,too-many-pu
             tc_cfg = self.args.tc_cfg
         #TODO: this bit is not compatible with IceteaManager's --tc argument.
         elif isinstance(self.args.tc, string_types) and os.path.exists(self.args.tc+'.json'):
-            tc_cfg = self.args.tc +'.json'
+            tc_cfg = self.args.tc + '.json'
 
         if tc_cfg:
             with open(tc_cfg) as data_file:
@@ -976,7 +976,7 @@ class Bench(object):  # pylint: disable=too-many-instance-attributes,too-many-pu
         if "kitty.exe" in putty_exe:
             params = params+' -title "'+self.duts[k-1].comport
 
-            params += ' - '+ self.get_test_name()
+            params += ' - ' + self.get_test_name()
             params += ' | DUT'+str(k)+' '+self.get_dut_nick(k)+'"'
             params += ' -log "' + LogManager.get_testcase_logfilename('DUT%d.manual' % k) + '"'
 

--- a/test/test_bench.py
+++ b/test/test_bench.py
@@ -341,5 +341,5 @@ class TestVerify(unittest.TestCase):
         self.assertEqual(len(bench._results), 1)
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     unittest.main()

--- a/test/test_logmanager.py
+++ b/test/test_logmanager.py
@@ -83,7 +83,7 @@ class ContextFilterTest(unittest.TestCase):
 
     def test_filter_binary_data(self):
         msg = []
-        [msg.append(os.urandom(1024)) for _ in range(ContextFilter.MAXIMUM_LENGTH +1)]
+        [msg.append(os.urandom(1024)) for _ in range(ContextFilter.MAXIMUM_LENGTH + 1)]
         msg = b"".join(msg)
         expected = "{}...[10240974 more bytes]".format(msg[:50])
         record = self.create_log_record(msg)

--- a/test/test_wireshark.py
+++ b/test/test_wireshark.py
@@ -259,5 +259,5 @@ class TestVerify(unittest.TestCase):
             self.assertTrue(raise LookupError())
     '''
 
-if __name__=='__main__':
+if __name__ == '__main__':
     unittest.main()

--- a/test/tests/test_tcTearDown.py
+++ b/test/tests/test_tcTearDown.py
@@ -72,5 +72,5 @@ class Testcase(Bench):
         pass
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     sys.exit(Testcase().run())


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.