### PR TITLE
Twine throws some error, let's add --verbose.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,5 +143,5 @@ jobs:
           command: |
             source venv/bin/activate
             export PATH=$HOME/.local/bin:$PATH
-            twine upload dist/*
+            twine upload --verbose dist/*
           # twine upload --repository-url https://test.pypi.org/legacy/ dist/*


### PR DESCRIPTION
## Status
**READY**

## Description
Pypi upload fails for some reason. Let's add verbose to diagnose.