### PR TITLE
Allow newer prettytable with newer python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-prettytable<1.0
+PrettyTable<=1.0.1; python_version < '3.6'
+prettytable>=2.0,<3.0; python_version >= '3.6'
 requests
 yattag>=1.0,<2.0
 pyserial>2.5


### PR DESCRIPTION
This helps to allow icetea fit into the same Python environment as
mbed-os-tools or mbed-os.

```pkg_resources.ContextualVersionConflict: (prettytable 0.7.2 (/usr/local/lib/python3.8/dist-packages), Requirement.parse('prettytable<3.0,>=2.0; python_version >= "3.6"'), {'mbed-os-tools'})```

Fixes #114